### PR TITLE
Fix start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,1 +1,1 @@
-(cd backend && python main.py) & (cd frontend && yarn && yarn start)
+(cd backend && python app.py) & (cd frontend && yarn && yarn start)


### PR DESCRIPTION
Changed cd backend && python main.py) to cd backend && python app.py). The file to execute in the backend directory is "app.py" but in the start.sh script it is targed to "main.sh" leading to error in execution.